### PR TITLE
Bugfix(mvn-builder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ The STAGE deploy pipeline requires the image tag that you want to deploy into ST
 
 1. Get an OpenShift cluster via https://try.openshift.com
 1. Install OpenShift Pipelines Operator
-1. Download [OpenShift CLI](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/) and [Tekton CLI](https://github.com/tektoncd/cli/releases) 
+1. Download [OpenShift CLI](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/) and [Tekton CLI](https://github.com/tektoncd/cli/releases)
 1. Deploy the demo
 
     ```
     $ oc new-project demo
-    $ git clone https://github.com/siamaksade/tekton-cd-demo 
+    $ git clone https://github.com/siamaksade/tekton-cd-demo
     $ demo.sh install
     ```
 
@@ -61,7 +61,7 @@ The STAGE deploy pipeline requires the image tag that you want to deploy into ST
 1. Check pipeline run logs
 
     ```
-    $ tkn pipeline logs petclinic-deploy-dev -f NAMESPACE
+    $ tkn pipeline logs petclinic-deploy-dev -n NAMESPACE
     ```
 
 ![Pipelines in Dev Console](docs/images/pipelines.png)
@@ -74,4 +74,3 @@ The STAGE deploy pipeline requires the image tag that you want to deploy into ST
 ## Why am I getting `unable to recognize "tasks/task.yaml": no matches for kind "Task" in version "tekton.dev/v1beta1"` errors?
 
 You might have just installed the OpenShift Pipelines operator on the cluster and the operator has not finished installing Tekton on the cluster yet. Wait a few minutes for the operator to finish and then install the demo.
-

--- a/tasks/mvn-task.yaml
+++ b/tasks/mvn-task.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   description: This Task can be used to run a Maven build.
   params:
-    - default: gcr.io/cloud-builders/mvn
+    - default: gcr.io/cloud-builders/mvn:3.5.0-jdk-8
       description: Maven base image
       name: MAVEN_IMAGE
       type: string


### PR DESCRIPTION
# Bugfix - Mvn Builder

## Fixes
1.  Documentation on how to get logs (in README)
2. Fix failing Sonarqube step (in mvn-task.yaml)

## Fix Details
### Documentation Bug
This is pretty straightforward, the namespace param was being passed in with the incorrect option.

### Sonarqube Bug
The Sonarqube step was failing due to an upgrade in the mvn builder.

Stacktrace:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 22.080 s
[INFO] Finished at: 2021-04-06T14:29:42Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.8.0.2131:sonar (default-cli) on project spring-petclinic: Unable to load component class org.sonar.plugins.javascript.JavaScriptSensor: ExceptionInInitializerError: java.lang.reflect.InaccessibleObjectException-->Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @6cfe48a4 -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

Sonarqube is pretty picky with the version of mvn/java it uses:
https://community.sonarsource.com/t/maven-sonar-scanner-not-working-with-jdk-16/40699

And looks like latest's update broke it.

`gcr.io/cloud-builders/mvn`, so just pinning it to mvn v3.5 and jdk v8 did the trick.