### PR TITLE
Fix EventListener for Pipelines 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,14 @@ The STAGE deploy pipeline requires the image tag that you want to deploy into ST
 1. Deploy the demo
 
     ```
-    $ oc new-project demo
     $ git clone https://github.com/siamaksade/tekton-cd-demo
-    $ demo.sh install
+    $ cd tekton-cd-demo && ./demo.sh install
     ```
 
 1. Start the deploy pipeline by making a change in the `spring-petclinic` Git repository on Gogs, or run the following:
 
     ```
-    $ demo.sh start
+    $ ./demo.sh start
     ```
 
 1. Check pipeline run logs

--- a/cd/gogs.yaml
+++ b/cd/gogs.yaml
@@ -166,7 +166,7 @@ spec:
   type: ClusterIP
 ---
 kind: Route
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 id: gogs-http
 metadata:
   labels:

--- a/cd/nexus.yaml
+++ b/cd/nexus.yaml
@@ -81,7 +81,7 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:

--- a/cd/reports-repo.yaml
+++ b/cd/reports-repo.yaml
@@ -91,7 +91,7 @@ spec:
     app: reports-repo
     deployment: reports-repo
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:

--- a/cd/sonarqube.yaml
+++ b/cd/sonarqube.yaml
@@ -78,7 +78,7 @@ spec:
       - name: sonarqube-logs
         emptyDir: {}
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:

--- a/triggers/eventlistener.yaml
+++ b/triggers/eventlistener.yaml
@@ -17,7 +17,7 @@ spec:
       bindings:
         - ref: gogs-triggerbinding
       template:
-        name: petclinic-trigger-template
+        ref: petclinic-trigger-template
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
@@ -29,7 +29,7 @@ metadata:
     eventlistener: webhook
 spec:
   port:
-    targetPort: 8080
+    targetPort: 8000
   to:
     kind: "Service"
     name: el-webhook


### PR DESCRIPTION
Fix `EventListener` [syntax](https://tekton.dev/docs/triggers/eventlisteners/#syntax) and webhook `targetPort` (switch from `8080` to `8000`).

>NOTE: tested with OpenShift 4.8 and OpenShift Pipelines 1.5.2

Signed-off-by: Jose Antonio Gonzalez Prada <josgonza@redhat.com>